### PR TITLE
optionally use base64-encoded strings in bench_upsert

### DIFF
--- a/python/bench_upsert.py
+++ b/python/bench_upsert.py
@@ -4,6 +4,8 @@ import pyperf
 
 import util
 
+NUM_DOCS = 1024
+BASE64_VECTORS = True
 
 def run_upsert_benchmark(docs):
     util.upsert_into(util.random_namespace(), docs)
@@ -21,7 +23,7 @@ def main():
 
     # Generate documents outside the benchmark function.
     if runner.args.worker:
-        upsert_docs = util.random_documents(num_docs=1024, text_content_size=8)
+        upsert_docs = util.random_documents(num_docs=NUM_DOCS, text_content_size=8, base64_vectors=BASE64_VECTORS)
 
     runner.bench_func(
         "upsert",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,6 +5,7 @@ description = "Benchmarks for the turbopuffer Python SDK"
 requires-python = ">=3.12"
 dependencies = [
     "pyperf>=2.9.0",
-    "turbopuffer[fast]>=0.1.33",
+    "numpy>=1.26.3",
+    "turbopuffer[fast]>=0.1.34",
     "typing-extensions>=4.12.2",
 ]

--- a/python/util.py
+++ b/python/util.py
@@ -1,3 +1,5 @@
+import base64
+import numpy as np
 import random
 import string
 import uuid
@@ -15,17 +17,21 @@ def random_string(size):
 def random_vector():
     return [random_float() for _ in range(VECTOR_DIMS)]
 
-def random_document(text_content_size):
+def random_vector_base64():
+    bytes = np.array(random_vector(), dtype=np.float32).tobytes()
+    return base64.b64encode(bytes).decode('utf-8')
+
+def random_document(text_content_size, base64_vectors=False):
     return {
         "id": str(uuid.uuid4()),
-        "vector": random_vector(),
+        "vector": random_vector_base64() if base64_vectors else random_vector(),
         "attributes": {
             "content": random_string(text_content_size)
         }
     }
 
-def random_documents(num_docs, text_content_size):
-    return [random_document(text_content_size) for _ in range(num_docs)]
+def random_documents(num_docs, text_content_size, base64_vectors=False):
+    return [random_document(text_content_size, base64_vectors) for _ in range(num_docs)]
 
 def random_namespace():
     return tpuf.Namespace(f"turbopuffer-sdk-bench-python-{random_string(12)}")


### PR DESCRIPTION
Depends on:
* https://github.com/turbopuffer/turbopuffer/pull/3041
* https://github.com/turbopuffer/turbopuffer-python/pull/66