### PR TITLE
Fix: exclude client init and tls handshake from benchmark

### DIFF
--- a/python-async/bench_upsert.py
+++ b/python-async/bench_upsert.py
@@ -5,8 +5,8 @@ import pyperf
 import util
 
 @util.wrap_async_thread
-async def run_upsert_benchmark(docs):
-    await util.upsert_into(util.random_namespace(util.new_client()), docs)
+async def run_upsert_benchmark(client, docs):
+    await util.upsert_into(util.random_namespace(client), docs)
 
 
 def main():
@@ -18,6 +18,9 @@ def main():
     runner.parse_args()
 
     util.start_async_thread()
+
+    # Create and reuse single client instance to avoid including init / TLS handshake in benchmark
+    client = util.new_client()
     upsert_docs = []
 
     # Generate documents outside the benchmark function.
@@ -27,6 +30,7 @@ def main():
     runner.bench_func(
         "upsert",
         run_upsert_benchmark,
+        client,
         upsert_docs,
     )
 

--- a/python/bench_upsert.py
+++ b/python/bench_upsert.py
@@ -5,8 +5,8 @@ import pyperf
 import util
 
 
-def run_upsert_benchmark(docs):
-    util.upsert_into(util.random_namespace(util.new_client()), docs)
+def run_upsert_benchmark(client, docs):
+    util.upsert_into(util.random_namespace(client), docs)
 
 
 def main():
@@ -17,6 +17,8 @@ def main():
     runner = pyperf.Runner(processes=1, warmups=1, values=10)
     runner.parse_args()
 
+    # Create and reuse single client instance to avoid including init / TLS handshake in benchmark
+    client = util.new_client()
     upsert_docs = []
 
     # Generate documents outside the benchmark function.
@@ -26,6 +28,7 @@ def main():
     runner.bench_func(
         "upsert",
         run_upsert_benchmark,
+        client,
         upsert_docs,
     )
 


### PR DESCRIPTION
The Python SDK upsert benchmark included the time of instantiating the Turbopuffer client and then its subsequent TCP connect + TLS handshake. This meant that the raw upsert time was actually **_faster_** than reported in the benchmark.

Other tpuf SDK benchmarks like Typescript exclude instantiation and connection setup from upsert calculations, so I assume this incongruence is non-intentional; comparisons across SDKs were not apples-to-apples.

Fixing to report proper values.


## Setup

Mac M3 Max
MacOS 15.6.1
128gb ram
NH, USA <-> `gcp-us-central1`
[py-spy](https://github.com/benfred/py-spy) 0.4.2

Tested against an initially-empty tpuf deployment

## Before

Full flamegraph (new connection is ~9%):
<img width="1724" height="853" alt="image" src="https://github.com/user-attachments/assets/961a60de-3755-4b6a-b8fc-6f272a86a37e" />

Zooming in to connection setup:

<img width="1727" height="409" alt="Screenshot 2026-06-28 at 00 23 58" src="https://github.com/user-attachments/assets/f8be9e8c-b877-442d-a9a9-9c70c44b0db2" />

## After

No more new TLS handshake.

Full flamegraph:
<img width="1200" height="1130" alt="pyspy-after" src="https://github.com/user-attachments/assets/cca277e3-f3bf-4503-b61e-5c06e3e9dcc2" />


## Result

<img width="344" height="162" alt="image" src="https://github.com/user-attachments/assets/f4301513-8b78-4b38-af02-bb9cab95957a" />